### PR TITLE
Fix resources extracted from pak_wii being unusable

### DIFF
--- a/src/retro_data_structures/compression.py
+++ b/src/retro_data_structures/compression.py
@@ -66,11 +66,13 @@ class LZOCompressedBlock(Adapter):
         self.segment_size = segment_size
 
     def _actual_segment_size(self, context):
+        # DEBUG: Set context._index to 1 on 1st pass
         decompressed_size = construct.evaluate(self.decompressed_size, context)
         segment_size = construct.evaluate(self.segment_size, context)
 
         # This is the same index than the one used when parsing a resource : this index is incorrect
         # when parsing a compressed block that isn't of index 0
+        # DEBUG : Set context._index back to 0 on 1st pass
         previous_segments = context._index * segment_size
         if previous_segments > decompressed_size:
             # This segment is redundant!

--- a/src/retro_data_structures/formats/cmpd.py
+++ b/src/retro_data_structures/formats/cmpd.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import construct
+from construct import Bytes, Const, FocusedSeq, IfThenElse, Int32ub, Struct
+
+from retro_data_structures.compression import LZOCompressedBlockCorruption
+
+CMPD = Struct(
+    magic=Const(b"CMPD"),
+    block_count=Int32ub,
+    block_header=construct.Array(
+        construct.this.block_count,
+        Struct(
+            flag=construct.Byte,
+            compressed_size=construct.Int24ub,
+            uncompressed_size=construct.Int32ub,
+        ),
+    ),
+    blocks=construct.Array(
+        construct.this.block_count,
+        IfThenElse(
+            lambda this: this.block_header[this._index].compressed_size
+            < this.block_header[this._index].uncompressed_size,
+            FocusedSeq(
+                "block",
+                block=LZOCompressedBlockCorruption(lambda this: this._.block_header[this._index].uncompressed_size),
+            ),
+            Bytes(lambda this: this.block_header[this._index].uncompressed_size),
+        ),
+    ),
+)
+
+
+class CMPDAdapter(construct.Adapter):
+    def _decode(self, obj, context, path):
+        return b"".join(obj.blocks)
+
+    # Going to rip a page out of PWE's book and compress everything in a single block
+    def _encode(self, uncompressed, context, path):
+        res = construct.Container(
+            [
+                ("magic", b"CMPD"),
+                ("block_count", 1),
+                (
+                    "block_header",
+                    construct.ListContainer(
+                        [
+                            construct.Container(
+                                [
+                                    ("flag", 0xA0),
+                                    ("compressed_size", None),
+                                    ("uncompressed_size", len(uncompressed)),
+                                ]
+                            ),
+                        ]
+                    ),
+                ),
+                (
+                    "blocks",
+                    construct.ListContainer(
+                        LZOCompressedBlockCorruption(len(uncompressed))._encode(uncompressed, context, path)
+                    ),
+                ),
+            ]
+        )
+        res.block_header[0].compressed_size = len(res.blocks[0])
+        return res
+
+
+CompressedPakResource = CMPDAdapter(CMPD)

--- a/src/retro_data_structures/formats/pak_wii.py
+++ b/src/retro_data_structures/formats/pak_wii.py
@@ -87,7 +87,7 @@ class PakFile:
     compressed_data: bytes | None
     extra: construct.Container | None = None
 
-    def get_decompressed(self, target_game: Game) -> bytes:
+    def get_decompressed(self, target_game: Game) -> bytes:  # Returns empty bytes for some reason ?
         if self.uncompressed_data is None:
             self.uncompressed_data = CompressedPakResource.parse(self.compressed_data, target_game=target_game)
         return self.uncompressed_data

--- a/src/retro_data_structures/formats/pak_wii.py
+++ b/src/retro_data_structures/formats/pak_wii.py
@@ -4,14 +4,14 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import construct
-from construct import Bytes, Const, FocusedSeq, IfThenElse, Int32ub, PrefixedArray, Struct
+from construct import Bytes, Const, Int32ub, PrefixedArray, Struct
 
 from retro_data_structures import game_check
 from retro_data_structures.base_resource import AssetId, AssetType, Dependency
 from retro_data_structures.common_types import AssetId64, FourCC, String
-from retro_data_structures.compression import LZOCompressedBlockCorruption
 from retro_data_structures.construct_extensions.alignment import AlignTo
 from retro_data_structures.construct_extensions.dict import make_dict
+from retro_data_structures.formats.cmpd import CompressedPakResource
 
 if TYPE_CHECKING:
     from retro_data_structures.game_check import Game
@@ -69,70 +69,6 @@ PAKNoData = Struct(
     resources=construct.Aligned(64, PrefixedArray(Int32ub, ConstructResourceHeader)),
     _resources_end=construct.Tell,
 )
-
-CMPD = Struct(
-    magic=Const(b"CMPD"),
-    block_count=Int32ub,
-    block_header=construct.Array(
-        construct.this.block_count,
-        Struct(
-            flag=construct.Byte,
-            compressed_size=construct.Int24ub,
-            uncompressed_size=construct.Int32ub,
-        ),
-    ),
-    blocks=construct.Array(
-        construct.this.block_count,
-        IfThenElse(
-            lambda this: this.block_header[this._index].compressed_size
-            < this.block_header[this._index].uncompressed_size,
-            FocusedSeq(
-                "block",
-                block=LZOCompressedBlockCorruption(lambda this: this._.block_header[this._index].uncompressed_size),
-            ),
-            Bytes(lambda this: this.block_header[this._index].uncompressed_size),
-        ),
-    ),
-)
-
-
-class CMPDAdapter(construct.Adapter):
-    def _decode(self, obj, context, path):
-        return b"".join(obj.blocks)
-
-    # Going to rip a page out of PWE's book and compress everything in a single block
-    def _encode(self, uncompressed, context, path):
-        res = construct.Container(
-            [
-                ("magic", b"CMPD"),
-                ("block_count", 1),
-                (
-                    "block_header",
-                    construct.ListContainer(
-                        [
-                            construct.Container(
-                                [
-                                    ("flag", 0xA0),
-                                    ("compressed_size", None),
-                                    ("uncompressed_size", len(uncompressed)),
-                                ]
-                            ),
-                        ]
-                    ),
-                ),
-                (
-                    "blocks",
-                    construct.ListContainer(
-                        LZOCompressedBlockCorruption(len(uncompressed))._encode(uncompressed, context, path)
-                    ),
-                ),
-            ]
-        )
-        res.block_header[0].compressed_size = len(res.blocks[0])
-        return res
-
-
-CompressedPakResource = CMPDAdapter(CMPD)
 
 
 @dataclasses.dataclass

--- a/src/retro_data_structures/formats/pak_wii.py
+++ b/src/retro_data_structures/formats/pak_wii.py
@@ -4,12 +4,12 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import construct
-from construct import Bytes, Const, FocusedSeq, IfThenElse, Int32ub, PrefixedArray, Rebuild, Struct, len_, this
+from construct import Bytes, Const, FocusedSeq, Int32ub, PrefixedArray, Struct
 
 from retro_data_structures import game_check
 from retro_data_structures.base_resource import AssetId, AssetType, Dependency
 from retro_data_structures.common_types import AssetId64, FourCC, String
-from retro_data_structures.compression import LZOCompressedBlock, ZlibCompressedBlock
+from retro_data_structures.compression import LZOCorruptionSegment
 from retro_data_structures.construct_extensions.alignment import AlignTo
 from retro_data_structures.construct_extensions.dict import make_dict
 
@@ -72,9 +72,24 @@ PAKNoData = Struct(
 
 CompressedPakResource = FocusedSeq(
     "data",
-    decompressed_size=Rebuild(Int32ub, len_(this.data)),
-    # Added Zlib check for DKCR
-    data=IfThenElse(game_check.uses_lzo, LZOCompressedBlock(this.decompressed_size), ZlibCompressedBlock),
+    magic=Const(b"CMPD"),
+    block_count=Int32ub,
+    block_header=construct.Array(
+        construct.this.block_count,
+        Struct(
+            flag=construct.Byte,
+            compressed_size=construct.Int24ub,
+            uncompressed_size=construct.Int32ub,
+        ),
+    ),
+    blocks=construct.Array(
+        construct.this.block_count,
+        LZOCorruptionSegment(
+            lambda this: this.block_header[this._index].compressed_size,
+            lambda this: this.block_header[this._index].uncompressed_size,
+        ),
+    ),
+    data=construct.Computed(lambda this: b"".join(this.blocks)),
 )
 
 

--- a/tests/formats/test_pak_wii.py
+++ b/tests/formats/test_pak_wii.py
@@ -105,8 +105,9 @@ def test_corruption_resource_decode(compressed_resource):
     # This seems to only return the first block
     # This is because parsing the second block fails because the context index is 0 instead of 1
     # hence providing the wrong length
-    # Manually providing the right index still fails, because the _actual_segment_size method uses
-    # that same index which raises a false StopFieldError
+    # In debug mode, manually setting the context._index to 1 when evaluating decompressed_size on 1st pass and
+    # segment_size in _actual_segment_size for LZOCompressedBlock, then setting it back to 0
+    # when computing previous_segments seems to fix the problem
     decoded = CompressedPakResource.parse(compressed_resource["contents"]["data"], target_game=Game.CORRUPTION)
 
     assert len(decoded) == len(compressed_resource["contents"]["value"])

--- a/tests/formats/test_pak_wii.py
+++ b/tests/formats/test_pak_wii.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 # The two following imports are only used by file tests
-from pathlib import Path
-
 import pytest
 
 from retro_data_structures.formats.pak import Pak
@@ -10,13 +8,6 @@ from retro_data_structures.formats.pak_wii import PAK_WII, CompressedPakResource
 from retro_data_structures.game_check import Game
 
 # ruff: noqa: E501
-
-# The following variables are used for file and debug tests and should be set before executing said tests locally
-pak_target = Path("C:/Users/belok/Emu/PAKTool/testpak.pak")
-pak_build_dir = Path("C:/Users/belok/Emu/PAKTool/Compressed-resources")
-resource_target = Path("C:/Users/belok/Emu/PAKTool/Metroid3-pak/434e8f026eb716a1.TXTR")
-prime3_iso_pak_target = "Metroid3.pak"
-csv_target = Path("C:/Users/belok/Emu/PAKTool/decompression_analysis.csv")
 
 paks = {
     "FrontEnd",
@@ -42,30 +33,46 @@ paks = {
 }
 
 
-@pytest.fixture(name="compressed_resource")
-def _compressed_resource():
+@pytest.fixture(name="compressed_resources")
+def _compressed_resources():
     """
-    The resource can be found in Metroid3.pak
+    The resources can be found in Metroid3.pak
     """
-    return {
-        "compressed": 1,
-        "asset": {"type": "TXTR", "id": 4849971089334802081},
-        "contents": {
-            "data": b"CMPD\x00\x00\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x0c\xc0\x00\x00\x11\x00\x00\x00\xa0"
-            b"\x00\x00\x00\n\x00\x10\x00\x10\x00\x00\x00\x02\x00\x0f\x16\x01\xe0\x02\xa0\xaa@\x00 "
-            b"w\x1c\x00\x11\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
-            "value": (
-                b"\x00\x00\x00\n\x00\x10\x00\x10\x00\x00\x00\x02\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02"
-                b"\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01"
-                b"\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa"
-                b"\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa"
-                b"\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02"
-                b"\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01"
-                b"\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa"
-                b"\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa"
-            ),
+    return [
+        {  # 2 segments resource
+            "compressed": 1,
+            "asset": {"type": "TXTR", "id": 4849971089334802081},
+            "contents": {
+                "data": b"CMPD\x00\x00\x00\x02\x00\x00\x00\x0c\x00\x00\x00\x0c\xc0\x00\x00\x11\x00\x00\x00\xa0"
+                b"\x00\x00\x00\n\x00\x10\x00\x10\x00\x00\x00\x02\x00\x0f\x16\x01\xe0\x02\xa0\xaa@\x00 "
+                b"w\x1c\x00\x11\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
+                "value": (
+                    b"\x00\x00\x00\n\x00\x10\x00\x10\x00\x00\x00\x02\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02"
+                    b"\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01"
+                    b"\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa"
+                    b"\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa"
+                    b"\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02"
+                    b"\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01"
+                    b"\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa"
+                    b"\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa\x01\xe0\x02\xa0\xaa\xaa\xaa\xaa"
+                ),
+            },
         },
-    }
+        {  # 1 segment resource
+            "compressed": 1,
+            "asset": {"type": "CSKR", "id": 2135532429836327754},
+            "contents": {
+                "data": b"CMPD\x00\x00\x00\x01\xa0\x00\x00*\x00\x00\x00J\x00(\x19SKIN\x00\x00\x00\x02M\x00\x01"
+                b"\xcf\x00\x03?\x80W\x00\x00\n\x1as\x00\x00\x00\xff/\x00\x00\xdc\x04+\x02\x00\x01\x00\x11\x00\x00"
+                b"\xff\xff\xff\xff\xff\xff",
+                "value": (
+                    b"SKIN\x00\x00\x00\x02\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x03?\x80\x00\x00\x00\x00\n"
+                    b"\x1a\x00\x00\x00\n\x00\x00\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+                    b"\xff\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00"
+                ),
+            },
+        },
+    ]
 
 
 def test_identical_when_keep_data(prime3_iso_provider):
@@ -101,223 +108,17 @@ def test_compare_header_keep_data(prime3_iso_provider):
         assert custom_sizes == raw_sizes
 
 
-def test_corruption_resource_decode(compressed_resource):
-    # This seems to only return the first block
-    # This is because parsing the second block fails because the context index is 0 instead of 1
-    # hence providing the wrong length
-    # In debug mode, manually setting the context._index to 1 when evaluating decompressed_size on 1st pass and
-    # segment_size in _actual_segment_size for LZOCompressedBlock, then setting it back to 0
-    # when computing previous_segments seems to fix the problem
-    decoded = CompressedPakResource.parse(compressed_resource["contents"]["data"], target_game=Game.CORRUPTION)
+def test_corruption_resource_decode(compressed_resources):
+    for compressed_resource in compressed_resources:
+        decoded = CompressedPakResource.parse(compressed_resource["contents"]["data"], target_game=Game.CORRUPTION)
 
-    assert len(decoded) == len(compressed_resource["contents"]["value"])
-    assert decoded == compressed_resource["contents"]["value"]
+        assert len(decoded) == len(compressed_resource["contents"]["value"])
+        assert decoded == compressed_resource["contents"]["value"]
 
 
-def test_corruption_resource_encode_decode(compressed_resource):
-    raw = compressed_resource["contents"]["value"]
-    decoded = CompressedPakResource.build(raw, target_game=Game.CORRUPTION)
-    encoded = CompressedPakResource.parse(decoded, target_game=Game.CORRUPTION)
-    assert raw == encoded
-
-
-# The following tests are what I call file tests :
-# They produce or read local files specified by the two global variables pak_target and pak_build_dir
-# They are NOT to be executed as tests by CI and are only here for reviewing the testing process
-
-
-# def test_write_new_pak():
-#     """
-#     This test writes an arbitrary pak file
-#     This is mostly to test whether written pak files work with Aruki's PakTool
-#     """
-#     game = Game.CORRUPTION
-#     files = [PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None), PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)]
-#     body = PakBody(
-#         b"joe mama so fat ", [("Hey its me Jack Block from minecraft", Dependency("STRG", 0xDEADBEEF))], files
-#     )
-
-#     output_pak = Pak(body, game)
-#     encoded = output_pak.build()
-
-#     with pak_target.open("wb") as fd:
-#         fd.write(encoded)
-
-
-# def test_build_from_extracted_pak():
-#     """
-#     This test builds a pak from a specified folder filled with different resources
-#     Its purpose is to rebuild a pak that was extracted via PakTool, see if it can be repackaged,
-#     and if the game can still run with the rebuilt pak
-#     """
-#     game = Game.CORRUPTION
-
-#     files = []
-#     for file in pak_build_dir.glob("*"):
-#         asset_id, asset_type = file.name.split(".")
-#         asset_id = int(asset_id.name, 16)
-
-#         data = b""
-#         with file.open("rb") as fd:
-#             data = fd.read()
-
-#         files.append(PakFile(asset_id, asset_type, False, data, None))
-
-#     # Values specific to Metroid3.pak
-#     body = PakBody(
-#         b"\x1b\x62\xf7\xca\x15\x60\xb1\x85\xc1\xe1\x09\x43\x99\x4f\xb9\xac",
-#         [
-#             ("03b_Bryyo_Fire_#SERIAL#", Dependency("MLVL", 0x9BA9292D588D6EB8)),
-#             ("03b_Bryyo_Reptilicus_#SERIAL#", Dependency("MLVL", 0x9F059B53561A9695)),
-#             ("03b_Bryyo_Ice_#SERIAL#", Dependency("MLVL", 0xB0D67636D61F3868)),
-#         ],
-#         files,
-#     )
-
-#     output_pak = Pak(body, game)
-#     encoded = output_pak.build()
-
-#     with pak_target.open("wb") as fd:
-#         fd.write(encoded)
-
-
-# def test_parse_new_pak():
-#     """
-#     This tests whether a pak file that was built with RDS can be parsed back
-#     """
-#     game = Game.CORRUPTION
-
-#     with pak_target.open("rb") as fd:
-#         raw = fd.read()
-
-#     decoded = Pak.parse(raw, game)
-#     return decoded
-
-
-# def test_resource_extraction(prime3_iso_provider):
-#     """
-#     This test is here to check whether a specific compressed resource is extracted properly by comparing it
-#     to a decompressed resource extracted by PakTool
-#     """
-#     game = Game.CORRUPTION
-
-#     with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
-#         raw = f.read()
-
-#     decoded = Pak.parse(raw, game)
-
-#     with resource_target.open("rb") as fd:
-#         original_data = fd.read()
-
-#     filename = resource_target.name
-#     original_id, original_type = filename.split(".")
-#     original_id = int(original_id, 16)
-
-#     # Search for target resource in pak
-#     for resource in decoded._raw.files:
-#         if resource.asset_id == original_id:
-#             pak_resource = resource
-#             break
-
-#     assert original_data == pak_resource.get_decompressed(game)
-
-# # The following functions are debug functions : they serve no purpose as tests and are only here
-# # to search for specific resources or look for patterns
-
-# def write_resources(target_dir : Path, resource_list : list[PakFile], decompressed : bool = True):
-#     for resource in resource_list :
-#         file_name = hex(resource.asset_id)[2:]
-#         file_extension = resource.asset_type
-
-#         output_file = target_dir / Path(file_name + "." + file_extension)
-#         with output_file.open("wb") as fd :
-#             fd.write(resource.uncompressed_data if decompressed else resource.compressed_data)
-
-# def test_get_all_compressed(prime3_iso_provider):
-#     game = Game.CORRUPTION
-
-#     with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
-#         raw = f.read()
-
-#     decoded = Pak.parse(raw, game)
-
-#     res = [cmpd_res for cmpd_res in decoded._raw.files if cmpd(cmpd_res)]
-#     write_resources(pak_build_dir, res, False)
-
-# def analyze_decompression(decoded_pak : Pak) -> dict[any : Exception | None] :
-#     """
-#     Analyzes the decompression process for all compressed resources within a given Pak file.
-#     Useful for running statistics of how decompression may fail depending on which factors.
-#     The tuple indices are as follows :
-#     0 : resource id
-#     1 : resource type
-#     2 : Number of compressed blocks
-#     """
-#     game = Game.CORRUPTION
-#     assert decoded_pak.target_game == game
-
-#     res = {}
-#     for cmpd_res in decoded_pak._raw.files :
-#         if cmpd_res.should_compress :
-#             exception = None
-#             id_str = hex(cmpd_res.asset_id)[2:]
-#             try :
-#                 cmpd_res.get_decompressed(game)
-#             except Exception as e:
-#                 exception = e
-#             finally :
-#                 res[(id_str, cmpd_res.asset_type, int.from_bytes(cmpd_res.compressed_data[4:8]))] = exception
-
-#     return res
-
-# def analyze_pak(prime3_iso_provider, pakfile):
-#     game = Game.CORRUPTION
-
-#     with prime3_iso_provider.open_binary(pakfile) as f:
-#         raw = f.read()
-
-#     decoded = Pak.parse(raw, game)
-
-#     res = analyze_decompression(decoded)
-#     return res
-
-# def test_analyze_game_exceptions(prime3_iso_provider):
-#     """
-#     Runs statistics on decompressing all resources in the game and logs them into a CSV
-#     Right now, it analyzes the outcome of decompression, which error is raised
-#     """
-#     game = Game.CORRUPTION
-#     res = {}
-
-#     # Counting errors and sorting them by error type
-#     for pakfile in paks:
-#         pak_analysis = analyze_pak(prime3_iso_provider, pakfile + ".pak")
-#         for exception in pak_analysis.values():
-#             if type(exception) not in res.keys():
-#                 res[type(exception)] = 1
-#             else :
-#                 res[type(exception)] += 1
-
-#     # Logging results into csv
-#     with csv_target.open("w") as fd_out:
-#         index = 0
-#         columns = list(res.items())
-#         for field in columns:
-#             fd_out.write(str(field[0]) + ("," if index < len(columns) - 1 else "\n"))
-#             index += 1
-#         index = 0
-#         for value in columns:
-#             fd_out.write(str(value[1]) + ("," if index < len(columns) - 1 else "\n"))
-#             index += 1
-
-
-# # The following functions only denote specific filters for PakFiles to target them specifically
-
-# def cmpd(resource : PakFile) -> bool:
-#     return resource.should_compress
-
-# def cmpd_gt_1_block(resource : PakFile) -> bool:
-#     return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x01")
-
-# def cmpd_gt_2_block(resource : PakFile) -> bool:
-#     return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x02")
+def test_corruption_resource_encode_decode(compressed_resources):
+    for compressed_resource in compressed_resources:
+        raw = compressed_resource["contents"]["value"]
+        decoded = CompressedPakResource.build(raw, target_game=Game.CORRUPTION)
+        encoded = CompressedPakResource.parse(decoded, target_game=Game.CORRUPTION)
+        assert raw == encoded

--- a/tests/formats/test_pak_wii.py
+++ b/tests/formats/test_pak_wii.py
@@ -79,6 +79,10 @@ def test_compare_header_keep_data(prime3_iso_provider):
 
 
 # def test_write_new_pak():
+#     """
+#     This test writes an arbitrary pak file
+#     This is mostly to test whether written pak files work with Aruki's PakTool
+#     """
 #     game = Game.CORRUPTION
 #     files = [PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None), PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)]
 #     body = PakBody(
@@ -93,6 +97,11 @@ def test_compare_header_keep_data(prime3_iso_provider):
 
 
 # def test_build_from_extracted_pak():
+#     """
+#     This test builds a pak from a specified folder filled with different resources
+#     Its purpose is to rebuild a pak that was extracted via PakTool, see if it can be repackaged,
+#     and if the game can still run with the rebuilt pak
+#     """
 #     game = Game.CORRUPTION
 
 #     files = []
@@ -125,6 +134,9 @@ def test_compare_header_keep_data(prime3_iso_provider):
 
 
 # def test_parse_new_pak():
+#     """
+#     This tests whether a pak file that was built with RDS can be parsed back
+#     """
 #     game = Game.CORRUPTION
 
 #     with pak_target.open("rb") as fd:
@@ -135,6 +147,10 @@ def test_compare_header_keep_data(prime3_iso_provider):
 
 
 # def test_resource_extraction(prime3_iso_provider):
+#     """
+#     This test is here to check whether a specific compressed resource is extracted properly by comparing it
+#     to a decompressed resource extracted by PakTool
+#     """
 #     game = Game.CORRUPTION
 
 #     with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:

--- a/tests/formats/test_pak_wii.py
+++ b/tests/formats/test_pak_wii.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
 # The two following imports are only used by file tests
-# from glob import glob
-# from os import path
-from retro_data_structures.formats.pak import Pak
-from retro_data_structures.formats.pak_wii import (
-    PAK_WII,
-    PAKNoData,
-)
+from pathlib import Path
 
-# The two following classes are only used by file tests
-# PakFile,
-# PakBody
+from retro_data_structures.base_resource import Dependency
+from retro_data_structures.formats.pak import Pak
+from retro_data_structures.formats.pak_wii import PAK_WII, PakBody, PakFile, PAKNoData
 from retro_data_structures.game_check import Game
 
 # ruff: noqa: E501
 
 # The following variables are only used for the file tests and should be set before executing said tests locally
-# pak_target = "."
-# pak_build_dir = "."
+pak_target = Path("C:/Users/belok/Emu/PAKTool/testpak.pak")
+pak_build_dir = Path("C:/Users/belok/Emu/PAKTool/Worlds.pak")
+resource_target = Path("C:/Users/belok/Emu/PAKTool/Worlds-pak/09ad3599129e8a2b.STRG")
 
 paks = {
     "FrontEnd",
@@ -81,61 +76,83 @@ def test_compare_header_keep_data(prime3_iso_provider):
 # They produce or read local files specified by the two global variables pak_target and pak_build_dir
 # They are NOT to be executed as tests by CI and are only here for reviewing the testing process
 
-# def test_write_new_pak():
-#     game = Game.CORRUPTION
-#     files = [
-#         PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None),
-#         PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)
-#     ]
-#     body = PakBody(b"joe mama so fat ", [
-#         ("Hey its me Jack Block from minecraft",
-#         Dependency("STRG", 0xDEADBEEF))
-#         ],
-#         files
-#     )
 
-#     output_pak = Pak(body, game)
-#     encoded = output_pak.build()
+def test_write_new_pak():
+    game = Game.CORRUPTION
+    files = [PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None), PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)]
+    body = PakBody(
+        b"joe mama so fat ", [("Hey its me Jack Block from minecraft", Dependency("STRG", 0xDEADBEEF))], files
+    )
 
-#     with open(pak_target, "wb") as fd :
-#         fd.write(encoded)
+    output_pak = Pak(body, game)
+    encoded = output_pak.build()
 
-# def test_build_from_extracted_pak():
-#     game = Game.CORRUPTION
+    with pak_target.open("wb") as fd:
+        fd.write(encoded)
 
-#     files = []
-#     for file in glob(pak_build_dir + "/*"):
-#         asset_id, asset_type = file.split(".")
-#         asset_id = int(path.basename(asset_id), 16)
 
-#         data = b""
-#         with open(file, "rb") as fd:
-#             data = fd.read()
+def test_build_from_extracted_pak():
+    game = Game.CORRUPTION
 
-#         files.append(PakFile(asset_id, asset_type, False, data, None))
+    files = []
+    for file in pak_build_dir.glob("*"):
+        asset_id, asset_type = file.name.split(".")
+        asset_id = int(asset_id.name, 16)
 
-#     body = PakBody(b"\x1B\x62\xF7\xCA\x15\x60\xB1\x85\xC1\xE1\x09\x43\x99\x4F\xB9\xAC", [
-#                     ("03b_Bryyo_Fire_#SERIAL#",
-#                     Dependency("MLVL", 0x9BA9292D588D6EB8)),
-#                     ("03b_Bryyo_Reptilicus_#SERIAL#",
-#                     Dependency("MLVL", 0x9F059B53561A9695)),
-#                     ("03b_Bryyo_Ice_#SERIAL#",
-#                     Dependency("MLVL", 0xB0D67636D61F3868))
-#                     ],
-#                 files
-#             )
+        data = b""
+        with file.open("rb") as fd:
+            data = fd.read()
 
-#     output_pak = Pak(body, game)
-#     encoded = output_pak.build()
+        files.append(PakFile(asset_id, asset_type, False, data, None))
 
-#     with open(pak_target, "wb") as fd:
-#         fd.write(encoded)
+    # Values specific to Metroid3.pak
+    body = PakBody(
+        b"\x1b\x62\xf7\xca\x15\x60\xb1\x85\xc1\xe1\x09\x43\x99\x4f\xb9\xac",
+        [
+            ("03b_Bryyo_Fire_#SERIAL#", Dependency("MLVL", 0x9BA9292D588D6EB8)),
+            ("03b_Bryyo_Reptilicus_#SERIAL#", Dependency("MLVL", 0x9F059B53561A9695)),
+            ("03b_Bryyo_Ice_#SERIAL#", Dependency("MLVL", 0xB0D67636D61F3868)),
+        ],
+        files,
+    )
 
-# def test_parse_new_pak():
-#     game = Game.CORRUPTION
+    output_pak = Pak(body, game)
+    encoded = output_pak.build()
 
-#     with open(pak_target, "rb") as fd:
-#         raw = fd.read()
+    with pak_target.open("wb") as fd:
+        fd.write(encoded)
 
-#     decoded = Pak.parse(raw, game)
-#     return decoded
+
+def test_parse_new_pak():
+    game = Game.CORRUPTION
+
+    with pak_target.open("rb") as fd:
+        raw = fd.read()
+
+    decoded = Pak.parse(raw, game)
+    return decoded
+
+
+def test_resource_extraction(prime3_iso_provider):
+    game = Game.CORRUPTION
+
+    with prime3_iso_provider.open_binary("Worlds.pak") as f:
+        raw = f.read()
+
+    decoded = Pak.parse(raw, game)
+
+    with resource_target.open("rb") as fd:
+        original_data = fd.read()
+
+    filename = resource_target.name
+    original_id, original_type = filename.split(".")
+    original_id = int(original_id, 16)
+
+    # Search for target resource in pak
+
+    for resource in decoded._raw.files:
+        if resource.asset_id == original_id:
+            pak_resource = resource
+            break
+
+    assert original_data == pak_resource.get_decompressed(game)

--- a/tests/formats/test_pak_wii.py
+++ b/tests/formats/test_pak_wii.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 # The two following imports are only used by file tests
 from pathlib import Path
 
-from retro_data_structures.base_resource import Dependency
 from retro_data_structures.formats.pak import Pak
-from retro_data_structures.formats.pak_wii import PAK_WII, PakBody, PakFile, PAKNoData
+from retro_data_structures.formats.pak_wii import PAK_WII, PAKNoData
 from retro_data_structures.game_check import Game
 
 # ruff: noqa: E501
@@ -15,6 +14,7 @@ pak_target = Path("C:/Users/belok/Emu/PAKTool/testpak.pak")
 pak_build_dir = Path("C:/Users/belok/Emu/PAKTool/Compressed-resources")
 resource_target = Path("C:/Users/belok/Emu/PAKTool/Compressed-resources/63344da1b78a8eb9.TXTR")
 prime3_iso_pak_target = "Metroid3.pak"
+csv_target = Path("C:/Users/belok/Emu/PAKTool/decompression_analysis.csv")
 
 paks = {
     "FrontEnd",
@@ -78,118 +78,182 @@ def test_compare_header_keep_data(prime3_iso_provider):
 # They are NOT to be executed as tests by CI and are only here for reviewing the testing process
 
 
-def test_write_new_pak():
-    game = Game.CORRUPTION
-    files = [PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None), PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)]
-    body = PakBody(
-        b"joe mama so fat ", [("Hey its me Jack Block from minecraft", Dependency("STRG", 0xDEADBEEF))], files
-    )
+# def test_write_new_pak():
+#     game = Game.CORRUPTION
+#     files = [PakFile(0xDEADBEEF, "STRG", False, b"abcdefg", None), PakFile(0xDEADD00D, "STRG", False, b"hijklmn", None)]
+#     body = PakBody(
+#         b"joe mama so fat ", [("Hey its me Jack Block from minecraft", Dependency("STRG", 0xDEADBEEF))], files
+#     )
 
-    output_pak = Pak(body, game)
-    encoded = output_pak.build()
+#     output_pak = Pak(body, game)
+#     encoded = output_pak.build()
 
-    with pak_target.open("wb") as fd:
-        fd.write(encoded)
-
-
-def test_build_from_extracted_pak():
-    game = Game.CORRUPTION
-
-    files = []
-    for file in pak_build_dir.glob("*"):
-        asset_id, asset_type = file.name.split(".")
-        asset_id = int(asset_id.name, 16)
-
-        data = b""
-        with file.open("rb") as fd:
-            data = fd.read()
-
-        files.append(PakFile(asset_id, asset_type, False, data, None))
-
-    # Values specific to Metroid3.pak
-    body = PakBody(
-        b"\x1b\x62\xf7\xca\x15\x60\xb1\x85\xc1\xe1\x09\x43\x99\x4f\xb9\xac",
-        [
-            ("03b_Bryyo_Fire_#SERIAL#", Dependency("MLVL", 0x9BA9292D588D6EB8)),
-            ("03b_Bryyo_Reptilicus_#SERIAL#", Dependency("MLVL", 0x9F059B53561A9695)),
-            ("03b_Bryyo_Ice_#SERIAL#", Dependency("MLVL", 0xB0D67636D61F3868)),
-        ],
-        files,
-    )
-
-    output_pak = Pak(body, game)
-    encoded = output_pak.build()
-
-    with pak_target.open("wb") as fd:
-        fd.write(encoded)
+#     with pak_target.open("wb") as fd:
+#         fd.write(encoded)
 
 
-def test_parse_new_pak():
-    game = Game.CORRUPTION
+# def test_build_from_extracted_pak():
+#     game = Game.CORRUPTION
 
-    with pak_target.open("rb") as fd:
-        raw = fd.read()
+#     files = []
+#     for file in pak_build_dir.glob("*"):
+#         asset_id, asset_type = file.name.split(".")
+#         asset_id = int(asset_id.name, 16)
 
-    decoded = Pak.parse(raw, game)
-    return decoded
+#         data = b""
+#         with file.open("rb") as fd:
+#             data = fd.read()
 
+#         files.append(PakFile(asset_id, asset_type, False, data, None))
 
-def test_resource_extraction(prime3_iso_provider):
-    game = Game.CORRUPTION
+#     # Values specific to Metroid3.pak
+#     body = PakBody(
+#         b"\x1b\x62\xf7\xca\x15\x60\xb1\x85\xc1\xe1\x09\x43\x99\x4f\xb9\xac",
+#         [
+#             ("03b_Bryyo_Fire_#SERIAL#", Dependency("MLVL", 0x9BA9292D588D6EB8)),
+#             ("03b_Bryyo_Reptilicus_#SERIAL#", Dependency("MLVL", 0x9F059B53561A9695)),
+#             ("03b_Bryyo_Ice_#SERIAL#", Dependency("MLVL", 0xB0D67636D61F3868)),
+#         ],
+#         files,
+#     )
 
-    with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
-        raw = f.read()
+#     output_pak = Pak(body, game)
+#     encoded = output_pak.build()
 
-    decoded = Pak.parse(raw, game)
-
-    with resource_target.open("rb") as fd:
-        original_data = fd.read()
-
-    filename = resource_target.name
-    original_id, original_type = filename.split(".")
-    original_id = int(original_id, 16)
-
-    # Search for target resource in pak
-    for resource in decoded._raw.files:
-        if resource.asset_id == original_id:
-            pak_resource = resource
-            break
-
-    assert original_data == pak_resource.get_decompressed(game)
+#     with pak_target.open("wb") as fd:
+#         fd.write(encoded)
 
 
-# The following functions are debug functions : they serve no purpose as tests and are only here
-# to search for specific resources or look for patterns
+# def test_parse_new_pak():
+#     game = Game.CORRUPTION
+
+#     with pak_target.open("rb") as fd:
+#         raw = fd.read()
+
+#     decoded = Pak.parse(raw, game)
+#     return decoded
 
 
-def write_resources(target_dir: Path, resource_list: list[PakFile], decompressed: bool = True):
-    for resource in resource_list:
-        file_name = hex(resource.asset_id)[2:]
-        file_extension = resource.asset_type
+# def test_resource_extraction(prime3_iso_provider):
+#     game = Game.CORRUPTION
 
-        output_file = target_dir / Path(file_name + "." + file_extension)
-        with output_file.open("wb") as fd:
-            fd.write(resource.uncompressed_data if decompressed else resource.compressed_data)
+#     with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
+#         raw = f.read()
+
+#     decoded = Pak.parse(raw, game)
+
+#     with resource_target.open("rb") as fd:
+#         original_data = fd.read()
+
+#     filename = resource_target.name
+#     original_id, original_type = filename.split(".")
+#     original_id = int(original_id, 16)
+
+#     # Search for target resource in pak
+#     for resource in decoded._raw.files:
+#         if resource.asset_id == original_id:
+#             pak_resource = resource
+#             break
+
+#     assert original_data == pak_resource.get_decompressed(game)
+
+# # The following functions are debug functions : they serve no purpose as tests and are only here
+# # to search for specific resources or look for patterns
+
+# def write_resources(target_dir : Path, resource_list : list[PakFile], decompressed : bool = True):
+#     for resource in resource_list :
+#         file_name = hex(resource.asset_id)[2:]
+#         file_extension = resource.asset_type
+
+#         output_file = target_dir / Path(file_name + "." + file_extension)
+#         with output_file.open("wb") as fd :
+#             fd.write(resource.uncompressed_data if decompressed else resource.compressed_data)
+
+# def test_get_all_compressed(prime3_iso_provider):
+#     game = Game.CORRUPTION
+
+#     with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
+#         raw = f.read()
+
+#     decoded = Pak.parse(raw, game)
+
+#     res = [cmpd_res for cmpd_res in decoded._raw.files if cmpd(cmpd_res)]
+#     write_resources(pak_build_dir, res, False)
+
+# def analyze_decompression(decoded_pak : Pak) -> dict[any : Exception | None] :
+#     """
+#     Analyzes the decompression process for all compressed resources within a given Pak file.
+#     Useful for running statistics of how decompression may fail depending on which factors.
+#     The tuple indices are as follows :
+#     0 : resource id
+#     1 : resource type
+#     2 : Number of compressed blocks
+#     """
+#     game = Game.CORRUPTION
+#     assert decoded_pak.target_game == game
+
+#     res = {}
+#     for cmpd_res in decoded_pak._raw.files :
+#         if cmpd_res.should_compress :
+#             exception = None
+#             id_str = hex(cmpd_res.asset_id)[2:]
+#             try :
+#                 cmpd_res.get_decompressed(game)
+#             except Exception as e:
+#                 exception = e
+#             finally :
+#                 res[(id_str, cmpd_res.asset_type, int.from_bytes(cmpd_res.compressed_data[4:8]))] = exception
+
+#     return res
+
+# def analyze_pak(prime3_iso_provider, pakfile):
+#     game = Game.CORRUPTION
+
+#     with prime3_iso_provider.open_binary(pakfile) as f:
+#         raw = f.read()
+
+#     decoded = Pak.parse(raw, game)
+
+#     res = analyze_decompression(decoded)
+#     return res
+
+# def test_analyze_game_exceptions(prime3_iso_provider):
+#     """
+#     Runs statistics on decompressing all resources in the game and logs them into a CSV
+#     Right now, it analyzes the outcome of decompression, which error is raised
+#     """
+#     game = Game.CORRUPTION
+#     res = {}
+
+#     # Counting errors and sorting them by error type
+#     for pakfile in paks:
+#         pak_analysis = analyze_pak(prime3_iso_provider, pakfile + ".pak")
+#         for exception in pak_analysis.values():
+#             if type(exception) not in res.keys():
+#                 res[type(exception)] = 1
+#             else :
+#                 res[type(exception)] += 1
+
+#     # Logging results into csv
+#     with csv_target.open("w") as fd_out:
+#         index = 0
+#         columns = list(res.items())
+#         for field in columns:
+#             fd_out.write(str(field[0]) + ("," if index < len(columns) - 1 else "\n"))
+#             index += 1
+#         index = 0
+#         for value in columns:
+#             fd_out.write(str(value[1]) + ("," if index < len(columns) - 1 else "\n"))
+#             index += 1
 
 
-def test_get_all_compressed(prime3_iso_provider):
-    game = Game.CORRUPTION
+# # The following functions only denote specific filters for PakFiles to target them specifically
 
-    with prime3_iso_provider.open_binary(prime3_iso_pak_target) as f:
-        raw = f.read()
+# def cmpd(resource : PakFile) -> bool:
+#     return resource.should_compress
 
-    decoded = Pak.parse(raw, game)
+# def cmpd_gt_1_block(resource : PakFile) -> bool:
+#     return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x01")
 
-    res = [cmpd_res for cmpd_res in decoded._raw.files if cmpd_gt_1_block(cmpd_res)]
-    write_resources(pak_build_dir, res, False)
-
-
-# The following functions only denote specific filters for PakFiles to target them specifically
-
-
-def cmpd_gt_1_block(resource: PakFile) -> bool:
-    return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x01")
-
-
-def cmpd_gt_2_block(resource: PakFile) -> bool:
-    return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x02")
+# def cmpd_gt_2_block(resource : PakFile) -> bool:
+#     return resource.should_compress and (resource.compressed_data[4:8] > b"\x00\x00\x00\x02")


### PR DESCRIPTION
We ran into problems trying to use resources that were extracted by pak_wii, causing RDS to raise exceptions