### PR TITLE
Fix build_module_dependencies breaking after adding a layer

### DIFF
--- a/src/retro_data_structures/formats/mrea.py
+++ b/src/retro_data_structures/formats/mrea.py
@@ -691,6 +691,7 @@ class Area:
         index = len(self._layer_names)
         self._layer_names.append(name)
         self._flags.append(active)
+        self.module_dependencies.append([])
         return self.mrea._create_script_layer(index, new_layer(index, self.asset_manager.target_game)).with_parent(self)
 
     @property

--- a/src/retro_data_structures/formats/script_layer.py
+++ b/src/retro_data_structures/formats/script_layer.py
@@ -256,6 +256,8 @@ class ScriptLayer:
         yield from self._parent_area.dependencies.layers[self._index]
 
     def build_module_dependencies(self) -> typing.Iterator[str]:
+        # FIXME: this copies the original dependencies when calculating the new values,
+        #  meaning it will never remove an entry
         rels = list(self.module_dependencies)
         for instance in self.instances:
             rels.extend(instance.get_properties().modules())


### PR DESCRIPTION
Fixing the FIXME breaks the tests due to one missing dep and deps being in a different order. 